### PR TITLE
Make backend API basePath configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -404,6 +404,17 @@ Automatically defines the APIcast public URLs based on a scheme.
   threescale_cicd_apicast_production_endpoint=https://my-wonderful-service.acme.corp/
   ```
 
+### `threescale_cicd_api_basepath`
+
+Defines a `basePath` on which is deployed the backend API, overriding the `basePath` field
+of the OpenAPI Specification. The resulting value is used to define the mapping rules of the
+3scale API Gateway, prepending this base path to paths of different methods/operations.
+
+- **Syntax:** URI part with starting /
+- **Required:** no
+- **Default value:** the `basePath` field of the OpenAPI Specification.
+- **Examples:** `/api` or `/context`
+
 ### `threescale_cicd_api_backend_hostname`
 
 Defines the backend hostname, overriding the `host` field of the OpenAPI Specification.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -50,6 +50,7 @@ threescale_cicd_openapi_smoketest_operation: '{{ threescale_cicd_openapi_file_co
 ##
 ## OpenAPI Specification File parsing
 ##
+threescale_cicd_api_basepath: '{{ threescale_cicd_openapi_file_content.basePath|default("") }}'
 threescale_cicd_api_base_system_name: '{{ lookup(''template'', ''openapi/generate_base_system_name.j2'') }}'
 threescale_cicd_api_system_name: '{{ lookup(''template'', ''openapi/generate_final_system_name.j2'') }}'
 threescale_cicd_private_base_url: '{{ lookup(''template'', ''openapi/private_base_url.j2'') }}'

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -24,7 +24,6 @@ threescale_cicd_api_default_name: '{{ threescale_cicd_openapi_file_content.info.
 threescale_cicd_api_name: '{{ lookup(''template'', ''openapi/service_name.j2'') }}'
 threescale_cicd_api_description: '{{ threescale_cicd_openapi_file_content.info.description|default("") }}'
 threescale_cicd_api_version: '{{ threescale_cicd_openapi_file_content.info.version|default("0.0.1") }}'
-threescale_cicd_api_basepath: '{{ threescale_cicd_openapi_file_content.basePath|default("") }}'
 threescale_cicd_api_operations: '{{ lookup(''template'', ''openapi/openapi_operations.j2'') }}'
 threescale_cicd_api_version_components: '{{ threescale_cicd_api_version.split(".") }}'
 threescale_cicd_api_version_major: '{{ threescale_cicd_api_version_components|first }}'


### PR DESCRIPTION
Deployed API base path is not always known in advance or can change from an environment to another one. This modification allows overriding API `basePath` as defined into the OpenAPI contract file. 