### PR TITLE
Adding support for adding CORS policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -447,6 +447,17 @@ Defines the 3scale Private Base URL.
 - **Default value:** `<threescale_cicd_api_backend_scheme>://<threescale_cicd_api_backend_hostname>`
 - **Example:** `http://mybackend.acme.corp:8080`
 
+### `threescale_cicd_apicast_policies_cors`
+
+Allows to enable the CORS policy onto APICast gateway. In case your API should support cross-origin
+and browser based invocations and you do not have included the `OPTIONS` verb on correct path into
+your OpenAPI Specification file...
+
+- **Syntax:** boolean `yes` or `no`
+- **Required:** no
+- **Default value:** `no`
+- **Example:** `yes` if you want to activate CORS policy on APICast
+
 ### `threescale_cicd_openapi_smoketest_operation`
 
 Defines the OpenAPI Specification method to use for smoke tests.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -23,6 +23,9 @@ threescale_cicd_local_bin_path: '{{ playbook_dir }}/bin'
 # Enable the OpenAPI Specification validation
 threescale_cicd_validate_openapi: yes
 
+# APIcast policies
+threescale_cicd_apicast_policies_cors: no
+
 # APIcast public base URLs
 threescale_cicd_apicast_sandbox_endpoint: '{{ lookup(''template'', ''openapi/apicast_sandbox_endpoint.j2'') }}'
 threescale_cicd_apicast_production_endpoint: '{{ lookup(''template'', ''openapi/apicast_production_endpoint.j2'') }}'

--- a/tasks/api-calls/update_policies.yml
+++ b/tasks/api-calls/update_policies.yml
@@ -1,0 +1,23 @@
+---
+
+- debug:
+    var: threescale_cicd_policies_to_update
+    verbosity: 1
+
+- debug:
+    var: threescale_cicd_update_policies_payload
+    verbosity: 1
+
+- name: Update the policies chain
+  uri:
+    url: https://{{ inventory_hostname }}/admin/api/services/{{ threescale_cicd_api_service_id }}/proxy/policies.json
+    validate_certs: no
+    method: PUT
+    body: '{{ threescale_cicd_update_policies_payload }}'
+    status_code: 200
+  register: threescale_cicd_tmpresponse
+  changed_when: 'threescale_cicd_tmpresponse.status == 200'
+
+- name: Wait for a couple seconds
+  pause:
+    seconds: '{{ threescale_cicd_throttling }}'

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -28,6 +28,9 @@
 # Update the proxy
 - import_tasks: steps/proxy.yml
 
+# Create or update policies
+- import_tasks: steps/policies.yml
+
 # Create or update application plans
 - import_tasks: steps/application_plans.yml
 

--- a/tasks/steps/policies.yml
+++ b/tasks/steps/policies.yml
@@ -1,0 +1,13 @@
+---
+
+- name: Retrieve existing policies from the 3scale Admin Portal
+  uri:
+    url: "https://{{ inventory_hostname }}/admin/api/services/{{ threescale_cicd_api_service_id }}/proxy/policies.json?access_token={{ threescale_cicd_access_token|urlencode }}"
+    validate_certs: no
+  register: threescale_cicd_tmpresponse
+
+- set_fact:
+    threescale_cicd_existing_policies_details: '{{ threescale_cicd_tmpresponse.json|json_query(''policies_config[]'') }}'
+
+- include_tasks: "api-calls/update_policies.yml"
+  with_items: '{{ threescale_cicd_policies_to_update }}'

--- a/templates/api-calls/update_policies.j2
+++ b/templates/api-calls/update_policies.j2
@@ -1,0 +1,7 @@
+{%
+  set payload = [
+    'access_token=' ~ threescale_cicd_access_token|urlencode,
+    'policies_config=' ~ threescale_cicd_policies_to_update|to_json|urlencode
+  ]
+%}
+{{ payload|join("&") }}

--- a/templates/existing_policies.j2
+++ b/templates/existing_policies.j2
@@ -1,0 +1,5 @@
+{% set policies = [] %}
+{% for value in threescale_cicd_existing_policies_details %}
+{% do policies.append( value ) %}
+{% endfor %}
+{{ policies }}

--- a/templates/wanted_policies.j2
+++ b/templates/wanted_policies.j2
@@ -1,0 +1,5 @@
+{% set policies = [] %}
+{% if threescale_cicd_apicast_policies_cors %}
+{% do policies.append( {"name": "cors", "version": "builtin", "configuration": {"allow_credentials": true}, "enabled": true} ) %}
+{% endif %}
+{{ policies }}

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -68,6 +68,16 @@ threescale_cicd_mapping_rules_to_delete: '{{ threescale_cicd_existing_mapping_ru
 threescale_cicd_mapping_rules_to_update: '{{ threescale_cicd_existing_mapping_rules.keys()|intersect(threescale_cicd_wanted_mapping_rules.keys()) }}'
 
 ##
+## Policies computation
+##
+## what we want
+threescale_cicd_wanted_policies: '{{ lookup(''template'', ''wanted_policies.j2'') }}'
+## what we have
+threescale_cicd_existing_policies: '{{ lookup(''template'', ''existing_policies.j2'') }}'
+# update the items that we want and we have
+threescale_cicd_policies_to_update: '{{ threescale_cicd_existing_policies|union(threescale_cicd_wanted_policies) }}'
+
+##
 ## 3scale API Payload definition
 ##
 threescale_cicd_update_proxy_payload: '{{ lookup(''template'', ''api-calls/update_proxy.j2'') }}'
@@ -77,6 +87,7 @@ threescale_cicd_update_method_payload: '{{ lookup(''template'', ''api-calls/upda
 threescale_cicd_create_method_payload: '{{ lookup(''template'', ''api-calls/create_method.j2'') }}'
 threescale_cicd_update_mapping_rule_payload: '{{ lookup(''template'', ''api-calls/update_mapping_rule.j2'') }}'
 threescale_cicd_create_mapping_rule_payload: '{{ lookup(''template'', ''api-calls/create_mapping_rule.j2'') }}'
+threescale_cicd_update_policies_payload: '{{ lookup(''template'', ''api-calls/update_policies.j2'') }}'
 threescale_cicd_update_application_plan_payload: '{{ lookup(''template'', ''api-calls/update_application_plan.j2'') }}'
 threescale_cicd_create_application_plan_payload: '{{ lookup(''template'', ''api-calls/create_application_plan.j2'') }}'
 threescale_cicd_find_application_payload: '{{ lookup(''template'', ''api-calls/find_application.j2'') }}'


### PR DESCRIPTION
This evolutions allows to add / remove CORS policy to APICast gateway.
It is driven by a new boolean property being `threescale_cicd_apicast_policies_cors` with default value to `no`