### PR TITLE
add support for one gateway environments (no staging gw)

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -42,7 +42,9 @@
 - include_tasks: steps/smoke_test.yml
   vars:
     threescale_cicd_smoke_test_env: staging
-  when: 'threescale_cicd_openapi_smoketest_operation|length > 0 and threescale_cicd_application_plans is defined'
+  when: >
+    threescale_cicd_openapi_smoketest_operation|length > 0 and threescale_cicd_application_plans is defined
+    and threescale_cicd_apicast_sandbox_endpoint != threescale_cicd_apicast_production_endpoint
 
 # Promote to production
 - import_tasks: steps/promote.yml


### PR DESCRIPTION
As requested in #35: add support for one gateway environments. That is to say when there is no staging gateway and only a production gateway. 

In that case, no smoke tests are run against the staging gateway and the service is directly promoted to the production gateway. 

To enable this support, the staging and production gateways need to have the same public base URL in the inventory. 

You can do that explicitly:

```ini
[threescale]
threescale_cicd_apicast_sandbox_endpoint=https://my-api.example.test
threescale_cicd_apicast_production_endpoint=https://my-api.example.test
```

Or implicitly:

```ini
[threescale]
threescale_cicd_api_base_system_name=my-api
threescale_cicd_wildcard_domain=example.test
threescale_cicd_default_staging_suffix=""
```