### PR TITLE
Link the ActiveDoc to the service

### DIFF
--- a/templates/api-calls/create_activedoc.j2
+++ b/templates/api-calls/create_activedoc.j2
@@ -6,6 +6,7 @@
     'system_name=' ~ threescale_cicd_api_system_name|urlencode,
     'body=' ~ threescale_cicd_openapi_rewritten|to_nice_json|urlencode,
     'published=true',
+    'service_id=' ~ threescale_cicd_api_service_id|urlencode,    
   ]
 %}
 {{ payload|join("&") }}


### PR DESCRIPTION
It is now possible to attach the Active Docs specs to a specific service, so all the specs for the service can be viewed from the `/apiconfig/services/<service_id>/api_docs`