### PR TITLE
Allow adding test application even when smoke tests are disabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -513,6 +513,15 @@ Override or update the list of supported OAuth flows for this API.
   - `threescale_cicd_oicd_flows="{{ [ 'application', 'accessCode' ] }}"` (override the flow list)
   - `threescale_cicd_oicd_flows="{{ [ 'application', threescale_cicd_api_security_scheme.flow ] }}"` (add a flow)
 
+### `threescale_cicd_create_default_application`
+
+Allows to create a test application with the default application plan, whether smoke tests are enabled or not.
+
+- **Syntax:** boolean (`yes`, `no`, `true`, `false`)
+- **Required:** no
+- **Default value:** `no`
+- **Example:** `yes` if you want a default application to be created
+
 ### Miscellaneous variables
 
 Miscellaneous variables defined in [defaults/main.yml](defaults/main.yml)

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -90,6 +90,11 @@ threescale_cicd_default_application_plan: '{{ (threescale_cicd_application_plans
 threescale_cicd_default_application_appid: '{{ (threescale_cicd_default_application_name ~ threescale_cicd_api_system_name ~ threescale_cicd_access_token)|hash(''sha1'') }}'
 threescale_cicd_default_application_appsecret: '{{ (''secret'' ~ threescale_cicd_default_application_name ~ threescale_cicd_api_system_name ~ threescale_cicd_access_token)|hash(''sha1'') }}'
 
+##
+## Create test application whether or not smoke tests are enabled
+##
+threescale_cicd_create_default_application: no
+
 # The OpenAPI Operation to use for the smoketest
 threescale_cicd_openapi_smoketest_operation: '{{ threescale_cicd_openapi_file_content|json_query(''paths.*.get[? "x-threescale-smoketests-operation" ].operationId'')|first|default("")|regex_replace(''[^0-9a-zA-Z_]+'', ''_'') }}'
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -43,7 +43,7 @@
 
 # Create or update the default application if smoke tests are needed
 - include_tasks: steps/default_application.yml
-  when: 'threescale_cicd_openapi_smoketest_operation|length > 0 and threescale_cicd_application_plans is defined'
+  when: (threescale_cicd_openapi_smoketest_operation|length > 0 or threescale_cicd_create_default_application|bool) and threescale_cicd_application_plans is defined
 
 # Run smoke tests on the staging gateway
 - include_tasks: steps/smoke_test.yml


### PR DESCRIPTION
Currently the test application with the default plan is only created when the smoke tests are enabled.
However, I need to be able to create an application with smoke tests disabled.
This is because I need to redeploy the APIcast gateway first, and run the tests after that.

In this PR this can be enabled by passing `threescale_cicd_create_test_application: true` var to the playbook.
Does it make sense @nmasse-itix ? Any feedback?